### PR TITLE
Configure signing distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
                      --stacktrace
                      assemble check
       - run:
+          name: Keyring
+          command: mkdir -p ~/.gnupg && echo "$SIGNING_SECRET_KEY_RING" | base64 --decode > ~/.gnupg/secring.gpg
+      - run:
           name: Deploy
           command: .circleci/deploy.sh
       - save_cache:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -17,6 +17,9 @@ elif [ "$CIRCLE_BRANCH" != "$BRANCH" ]; then
     echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$CIRCLE_BRANCH'."
 else
     echo "Deploying snapshot..."
-    ./gradlew uploadArchives
+    ./gradlew uploadArchives \
+        -Psigning.keyId="$SIGNING_KEY_ID" \
+        -Psigning.password="$SIGNING_PASSWORD" \
+        -Psigning.secretKeyRingFile="$HOME/.gnupg/secring.gpg"
     echo "Snapshot deployed!"
 fi


### PR DESCRIPTION
# Signing configuration

## Generation

```
gpg --full-generate-key
```

## Key ID

Obtained the key ID via:

```
gpg --list-keys --keyid-format SHORT
```

## Key ring

Per [The Signing Plugin], exported secret key ring file via:

```
gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg
```

The key ring was then base64'd for use in CircleCI:

```
cat ~/.gnupg/secring.gpg | base64 > ~/.gnupg/secring.gpg.base64
```

## Key server

Distributed the public key via:

```
gpg --keyserver hkp://pool.sks-keyservers.net --send-keys $KEY_ID
gpg --keyserver keyserver.ubuntu.com --send-keys $KEY_ID
```

_At the of this commit, propagation of public key can take 10-20 minutes._

Check status via: `http://pool.sks-keyservers.net/pks/lookup?search=0x$KEY_ID`


[The Signing Plugin]: https://docs.gradle.org/current/userguide/signing_plugin.html