### PR TITLE
Release Gatt lock on Android BLE method failure (fixes #34)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         'coroutines': '1.0.0',
 
         'kotlinTestJunit': '1.3.0',
-        'mockitoKotlin': '2.0.0-RC1',
+        'mockK': '1.9.3',
         'equalsVerifier': '2.5.2'
     ]
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlinTestJunit}"
 
-    // [Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin)
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockitoKotlin}"
+    // [MockK](https://github.com/mockk/mockk)
+    testImplementation "io.mockk:mockk:${versions.mockK}"
 
     // [EqualsVerifier](https://github.com/jqno/equalsverifier)
     testImplementation "nl.jqno.equalsverifier:equalsverifier:${versions.equalsVerifier}"

--- a/core/src/main/java/messenger/Messenger.kt
+++ b/core/src/main/java/messenger/Messenger.kt
@@ -45,8 +45,13 @@ class Messenger internal constructor(
                     bluetoothGatt.writeDescriptor(message.descriptor)
                 }
             }
+
             Able.debug { "Processed ${message.javaClass.simpleName}, result=$result" }
             message.response.complete(result)
+
+            if (!result) {
+                callback.notifyGattReady()
+            }
         }
         Able.verbose { "End" }
     }

--- a/core/src/test/java/CoroutinesGattTest.kt
+++ b/core/src/test/java/CoroutinesGattTest.kt
@@ -11,7 +11,8 @@ import android.bluetooth.BluetoothProfile.STATE_CONNECTED
 import com.juul.able.experimental.messenger.GattCallback
 import com.juul.able.experimental.messenger.GattCallbackConfig
 import com.juul.able.experimental.messenger.Messenger
-import com.nhaarman.mockitokotlin2.mock
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
@@ -40,7 +41,7 @@ class CoroutinesGattTest {
         val numberOfFakeBinderThreads = 10
         val onCharacteristicChangedCapacity = numberOfFakeCharacteristicNotifications.toInt()
 
-        val bluetoothGatt = mock<BluetoothGatt>()
+        val bluetoothGatt = mockk<BluetoothGatt>()
         val callback = GattCallback(GattCallbackConfig(onCharacteristicChangedCapacity)).apply {
             onConnectionStateChange(bluetoothGatt, GATT_SUCCESS, STATE_CONNECTED)
         }
@@ -78,9 +79,9 @@ class CoroutinesGattTest {
 private fun mockCharacteristic(
     uuid: UUID = UUID.randomUUID(),
     data: ByteArray? = null
-): BluetoothGattCharacteristic = mock {
-    on { getUuid() }.thenReturn(uuid)
-    on { value }.thenReturn(data)
+): BluetoothGattCharacteristic = mockk {
+    every { getUuid() } returns uuid
+    every { value } returns data
 }
 
 private fun Long.asByteArray(): ByteArray = ByteBuffer.allocate(8).putLong(this).array()

--- a/core/src/test/java/MessagesTest.kt
+++ b/core/src/test/java/MessagesTest.kt
@@ -9,8 +9,8 @@ import android.bluetooth.BluetoothGattDescriptor
 import com.juul.able.experimental.messenger.OnCharacteristicChanged
 import com.juul.able.experimental.messenger.OnCharacteristicRead
 import com.juul.able.experimental.messenger.OnDescriptorRead
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import nl.jqno.equalsverifier.EqualsVerifier
 import org.junit.Test
 import java.util.UUID
@@ -40,15 +40,15 @@ class MessagesTest {
 
 private fun mockDescriptor(uuidString: String): BluetoothGattDescriptor {
     val uuid = UUID.fromString(uuidString)
-    return mock {
-        whenever(it.uuid).thenReturn(uuid)
+    return mockk {
+        every { getUuid() } returns uuid
     }
 }
 
 private fun mockCharacteristic(uuidString: String): BluetoothGattCharacteristic {
     val uuid = UUID.fromString(uuidString)
-    return mock {
-        whenever(it.uuid).thenReturn(uuid)
+    return mockk {
+        every { getUuid() } returns uuid
     }
 }
 


### PR DESCRIPTION
When Android BLE returns `false` for it's `BluetoothGatt` methods, then we need to release the Gatt lock since we won't receive a call in the `BluetoothGattCallback` (which is normally responsible for releasing the lock).

Fixes #34 