### PR TITLE
Use badge to show latest version in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,13 @@ fun continuallyReadCharacteristic(gatt: Gatt, serviceUuid: UUID, characteristicU
 
 ## Gradle
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.able/core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.able/core)
+
 To use **Able** in your Android project, setup your `build.gradle` as follows:
 
 ```groovy
 dependencies {
-    implementation "com.juul.able:core:0.8.0"
+    implementation "com.juul.able:core:$version"
 }
 ```
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -34,8 +34,10 @@ val gatt = device
 
 ## Gradle
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.able/processor/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.able/processor)
+
 ```groovy
 dependencies {
-    implementation "com.juul.able:processor:0.8.0"
+    implementation "com.juul.able:processor:$version"
 }
 ```

--- a/throw/README.md
+++ b/throw/README.md
@@ -22,8 +22,10 @@ fun connect(context: Context, device: BluetoothDevice) = launch {
 
 ## Gradle
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.able/throw/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.able/throw)
+
 ```groovy
 dependencies {
-    implementation "com.juul.able:throw:0.8.0"
+    implementation "com.juul.able:throw:$version"
 }
 ```

--- a/timber-logger/README.md
+++ b/timber-logger/README.md
@@ -10,8 +10,10 @@ Able.logger = TimberLogger()
 
 ## Gradle
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.able/timber-logger/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.able/timber-logger)
+
 ```groovy
 dependencies {
-    implementation "com.juul.able:timber-logger:0.8.0"
+    implementation "com.juul.able:timber-logger:$version"
 }
 ```


### PR DESCRIPTION
Used [softwaremill/maven-badges](https://github.com/softwaremill/maven-badges) as it provided a badge without the `v` prefix (shields.io had a `v` prefix and could be confusing for users).

## Comparison

| shields.io | softwaremill/maven-badges |
|:-:|:-:|
| ![shields.io](https://img.shields.io/maven-central/v/com.juul.able/core) | ![softwaremill/maven-badges](https://maven-badges.herokuapp.com/maven-central/com.juul.able/core/badge.svg) |

## [README.md](https://github.com/JuulLabs-OSS/able/tree/twyatt/badge/version)

<img width="575" alt="Screen Shot 2020-04-07 at 2 40 07 PM" src="https://user-images.githubusercontent.com/98017/78722123-b354b500-78dd-11ea-9a8b-ecfb30fbb7b6.png">
