### PR TITLE
Improve stacktrace on connection loss for bluetooth request

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ sealed class ConnectGattResult {
 <sup>1</sup> _Suspends until `STATE_CONNECTED` or non-`GATT_SUCCESS` is received._<br/>
 <sup>2</sup> _Suspends until `STATE_DISCONNECTED` or non-`GATT_SUCCESS` is received, then calls `close()` on underlying [`BluetoothGatt`]._<br/>
 <sup>3</sup> _Throws [`RemoteException`] if underlying [`BluetoothGatt`] call returns `false`._<br/>
-<sup>3</sup> _Throws `ConnectionLost` if `Gatt` is closed while method is executing._<br/>
+<sup>3</sup> _Throws `GattResponseFailure` if an error occurs while waiting for response (e.g. connection is lost)._<br/>
 
 ### Details
 

--- a/core/src/main/java/gatt/CoroutinesGatt.kt
+++ b/core/src/main/java/gatt/CoroutinesGatt.kt
@@ -44,6 +44,7 @@ class CoroutinesGatt internal constructor(
 
     override suspend fun disconnect() {
         try {
+            Able.info { "Disconnecting $this" }
             bluetoothGatt.disconnect()
             suspendUntilConnectionState(STATE_DISCONNECTED)
         } finally {

--- a/core/src/main/java/gatt/CoroutinesGatt.kt
+++ b/core/src/main/java/gatt/CoroutinesGatt.kt
@@ -24,7 +24,7 @@ class OutOfOrderGattCallback(message: String) : IllegalStateException(message)
 
 class GattResponseFailure(
     message: String,
-    cause: Throwable?
+    cause: Throwable
 ) : IllegalStateException(message, cause)
 
 class CoroutinesGatt internal constructor(

--- a/core/src/main/java/gatt/CoroutinesGatt.kt
+++ b/core/src/main/java/gatt/CoroutinesGatt.kt
@@ -12,6 +12,7 @@ import android.bluetooth.BluetoothProfile.STATE_DISCONNECTED
 import android.os.RemoteException
 import com.juul.able.Able
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.asFlow
@@ -132,6 +133,8 @@ class CoroutinesGatt internal constructor(
         Able.verbose { "$methodName ← Waiting for BluetoothGattCallback" }
         val response = try {
             callback.onResponse.receive()
+        } catch (e: CancellationException) {
+            throw CancellationException("Waiting on response for $methodName was cancelled", e)
         } catch (e: Exception) {
             throw GattResponseFailure("Failed to receive response for $methodName", e)
         }

--- a/core/src/test/java/gatt/CoroutinesGattTest.kt
+++ b/core/src/test/java/gatt/CoroutinesGattTest.kt
@@ -495,10 +495,13 @@ class CoroutinesGattTest {
 
                 didReadCharacteristic.receive()
 
-                // Give `performBluetoothAction` some time to start "listening" for response (by
-                // invoking `receive` on `onResponse` Channel).
+                // Give `performBluetoothAction` some time to start "listening" for response (i.e.
+                // time to reach `callback.onResponse.receive()` call in `performBluetoothAction`).
                 delay(500L)
 
+                // Throws an Exception if `performBluetoothAction` throws a
+                // non-CancellationException on cancellation request, thereby validating that we
+                // honored cancellation appropriately if this call doesn't throw an Exception.
                 job.cancelAndJoin()
             }
         }

--- a/core/src/test/java/gatt/CoroutinesGattTest.kt
+++ b/core/src/test/java/gatt/CoroutinesGattTest.kt
@@ -14,8 +14,10 @@ import android.bluetooth.BluetoothProfile.STATE_CONNECTED
 import android.bluetooth.BluetoothProfile.STATE_DISCONNECTED
 import android.bluetooth.BluetoothProfile.STATE_DISCONNECTING
 import android.os.RemoteException
+import com.juul.able.gatt.ConnectionLost
 import com.juul.able.gatt.CoroutinesGatt
 import com.juul.able.gatt.GattCallback
+import com.juul.able.gatt.GattResponseFailure
 import com.juul.able.gatt.OnCharacteristicChanged
 import com.juul.able.gatt.OnCharacteristicRead
 import com.juul.able.gatt.OnCharacteristicWrite
@@ -325,8 +327,8 @@ class CoroutinesGattTest {
         createDispatcher().use { dispatcher ->
             val callback = GattCallback(dispatcher)
             val bluetoothGatt = mockk<BluetoothGatt> {
+                every { close() } returns Unit
                 every { device } returns mockk {
-                    every { close() } returns Unit
                     every { this@mockk.toString() } returns "00:11:22:33:FF:EE"
                 }
                 every { disconnect() } answers {
@@ -349,8 +351,8 @@ class CoroutinesGattTest {
         createDispatcher().use { dispatcher ->
             val callback = GattCallback(dispatcher)
             val bluetoothGatt = mockk<BluetoothGatt> {
+                every { close() } returns Unit
                 every { device } returns mockk {
-                    every { close() } returns Unit
                     every { this@mockk.toString() } returns "00:11:22:33:FF:EE"
                 }
                 every { disconnect() } answers {
@@ -377,8 +379,8 @@ class CoroutinesGattTest {
         createDispatcher().use { dispatcher ->
             val callback = GattCallback(dispatcher)
             val bluetoothGatt = mockk<BluetoothGatt> {
+                every { close() } returns Unit
                 every { device } returns mockk {
-                    every { close() } returns Unit
                     every { this@mockk.toString() } returns "00:11:22:33:FF:EE"
                 }
             }
@@ -415,8 +417,8 @@ class CoroutinesGattTest {
         createDispatcher().use { dispatcher ->
             val callback = GattCallback(dispatcher)
             val bluetoothGatt = mockk<BluetoothGatt> {
+                every { close() } returns Unit
                 every { device } returns mockk {
-                    every { close() } returns Unit
                     every { this@mockk.toString() } returns "00:11:22:33:FF:EE"
                 }
             }
@@ -432,6 +434,37 @@ class CoroutinesGattTest {
                 expected = emptyList(),
                 actual = events
             )
+        }
+    }
+
+    @Test
+    fun `Gatt action throws GattResponseFailure if connection drops while executing request`() {
+        createDispatcher().use { dispatcher ->
+            val callback = GattCallback(dispatcher)
+            val bluetoothGatt = mockk<BluetoothGatt> {
+                every { close() } returns Unit
+                every { device } returns mockk {
+                    every { this@mockk.toString() } returns "00:11:22:33:FF:EE"
+                }
+                every { readCharacteristic(any()) } answers {
+                    callback.onConnectionStateChange(this@mockk, GATT_SUCCESS, STATE_DISCONNECTED)
+                    true
+                }
+            }
+
+            val gatt = CoroutinesGatt(bluetoothGatt, dispatcher, callback)
+            runBlocking {
+                val cause = assertFailsWith<GattResponseFailure> {
+                    gatt.readCharacteristic(createCharacteristic())
+                }.cause
+
+                assertEquals<Class<out Throwable>>(
+                    expected = ConnectionLost::class.java,
+                    actual = cause!!.javaClass
+                )
+            }
+
+            verify(exactly = 1) { bluetoothGatt.close() }
         }
     }
 }

--- a/core/src/test/java/gatt/CoroutinesGattTest.kt
+++ b/core/src/test/java/gatt/CoroutinesGattTest.kt
@@ -496,7 +496,7 @@ class CoroutinesGattTest {
                 didReadCharacteristic.receive()
 
                 // Give `performBluetoothAction` some time to start "listening" for response (by
-                // invoking `receive` on `onResponse` Channel.
+                // invoking `receive` on `onResponse` Channel).
                 delay(500L)
 
                 job.cancelAndJoin()


### PR DESCRIPTION
Rethrow `ConnectionLost` from `CoroutinesGatt.performBluetoothAction` to provide more informative stacktrace.

## Before

```java
    com.juul.able.gatt.ConnectionLost
        at com.juul.able.gatt.GattCallback.onDisconnecting(GattCallback.kt:39)
        at com.juul.able.gatt.GattCallback.close(GattCallback.kt:45)
        at com.juul.able.gatt.GattCallback.onConnectionStateChange(GattCallback.kt:65)
        at android.bluetooth.BluetoothGatt$1$4.run(BluetoothGatt.java:272)
        at android.bluetooth.BluetoothGatt.runOrQueueCallback(BluetoothGatt.java:780)
        at android.bluetooth.BluetoothGatt.access$200(BluetoothGatt.java:41)
        at android.bluetooth.BluetoothGatt$1.onClientConnectionState(BluetoothGatt.java:267)
        at android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:192)
        at android.os.Binder.execTransactInternal(Binder.java:1021)
        at android.os.Binder.execTransact(Binder.java:994)
```

## After

```java
    com.juul.able.gatt.GattResponseFailure: Failed to receive response for discoverServices
        at com.juul.able.gatt.CoroutinesGatt.discoverServices(CoroutinesGatt.kt:186)
        at com.juul.able.gatt.CoroutinesGatt$discoverServices$1.invokeSuspend(Unknown Source:11)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:55)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: com.juul.able.gatt.ConnectionLost
        at com.juul.able.gatt.GattCallback.onDisconnecting(GattCallback.kt:39)
        at com.juul.able.gatt.GattCallback.close(GattCallback.kt:45)
        at com.juul.able.gatt.GattCallback.onConnectionStateChange(GattCallback.kt:65)
        at android.bluetooth.BluetoothGatt$1$4.run(BluetoothGatt.java:272)
        at android.bluetooth.BluetoothGatt.runOrQueueCallback(BluetoothGatt.java:780)
        at android.bluetooth.BluetoothGatt.access$200(BluetoothGatt.java:41)
        at android.bluetooth.BluetoothGatt$1.onClientConnectionState(BluetoothGatt.java:267)
        at android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:192)
        at android.os.Binder.execTransactInternal(Binder.java:1021)
        at android.os.Binder.execTransact(Binder.java:994)
```