### PR TITLE
Remove FailedToDeliverEvent Exception

### DIFF
--- a/core/src/main/java/gatt/Gatt.kt
+++ b/core/src/main/java/gatt/Gatt.kt
@@ -72,8 +72,6 @@ typealias WriteType = Int
 
 class ConnectionLost : Exception()
 
-class FailedToDeliverEvent(message: String) : IllegalStateException(message)
-
 class GattStatusFailure(
     val event: OnConnectionStateChange
 ) : IllegalStateException("Received $event")

--- a/core/src/main/java/gatt/GattCallback.kt
+++ b/core/src/main/java/gatt/GattCallback.kt
@@ -78,8 +78,7 @@ internal class GattCallback(
 
     override fun onServicesDiscovered(gatt: BluetoothGatt, status: GattStatus) {
         Able.verbose { "← OnServicesDiscovered(status=${status.asGattStatusString()})" }
-        onResponse.offer(status) ||
-            throw FailedToDeliverEvent("OnServicesDiscovered(status=${status.asGattStatusString()})")
+        onResponse.offer(status)
     }
 
     override fun onCharacteristicRead(
@@ -126,6 +125,6 @@ internal class GattCallback(
 
     private fun emitEvent(event: Any) {
         Able.verbose { "← $event" }
-        onResponse.offer(event) || throw FailedToDeliverEvent(event.toString())
+        onResponse.offer(event)
     }
 }


### PR DESCRIPTION
Was thrown if we failed to `offer` response in `GattCallback`, but `onResponse` is a `CONFLATED` `Channel` so will never return `false` (i.e. this `Exception` would never be thrown).

We're protected by the `Mutex` in `CoroutinesGatt` which enforces that requests are executed sequentially, so we should never have a response trample a previous (i.e. response is received from `onResponse` `Channel` prior to the next request going out).