### PR TITLE
Rename GattState to GattConnectionState

### DIFF
--- a/core/src/main/java/gatt/Debug.kt
+++ b/core/src/main/java/gatt/Debug.kt
@@ -81,14 +81,6 @@ private const val GATT_CCC_CFG_ERR = 0xFD
 private const val GATT_PRC_IN_PROGRESS = 0xFE
 private const val GATT_OUT_OF_RANGE = 0xFF
 
-internal fun GattState.asGattStateString() = when (this) {
-    STATE_DISCONNECTING -> "STATE_DISCONNECTING"
-    STATE_DISCONNECTED -> "STATE_DISCONNECTED"
-    STATE_CONNECTING -> "STATE_CONNECTING"
-    STATE_CONNECTED -> "STATE_CONNECTED"
-    else -> "STATE_UNKNOWN"
-}.let { name -> "$name($this)" }
-
 internal fun GattConnectionStatus.asGattConnectionStatusString() = when (this) {
     GATT_SUCCESS -> "GATT_SUCCESS"
     GATT_CONN_L2C_FAILURE -> "GATT_CONN_L2C_FAILURE"
@@ -99,6 +91,14 @@ internal fun GattConnectionStatus.asGattConnectionStatusString() = when (this) {
     GATT_CONN_LMP_TIMEOUT -> "GATT_CONN_LMP_TIMEOUT"
     GATT_CONN_CANCEL -> "GATT_CONN_CANCEL"
     else -> "GATT_CONN_UNKNOWN"
+}.let { name -> "$name($this)" }
+
+internal fun GattConnectionState.asGattConnectionStateString() = when (this) {
+    STATE_DISCONNECTING -> "STATE_DISCONNECTING"
+    STATE_DISCONNECTED -> "STATE_DISCONNECTED"
+    STATE_CONNECTING -> "STATE_CONNECTING"
+    STATE_CONNECTED -> "STATE_CONNECTED"
+    else -> "STATE_UNKNOWN"
 }.let { name -> "$name($this)" }
 
 internal fun GattStatus.asGattStatusString() = when (this) {

--- a/core/src/main/java/gatt/Events.kt
+++ b/core/src/main/java/gatt/Events.kt
@@ -9,12 +9,12 @@ import android.bluetooth.BluetoothGattDescriptor
 
 data class OnConnectionStateChange(
     val status: GattStatus,
-    val newState: GattState
+    val newState: GattConnectionState
 ) {
     override fun toString(): String {
         val connectionStatus = status.asGattConnectionStatusString()
-        val gattState = newState.asGattStateString()
-        return "OnConnectionStateChange(status=$connectionStatus, newState=$gattState)"
+        val connectionState = newState.asGattConnectionStateString()
+        return "OnConnectionStateChange(status=$connectionStatus, newState=$connectionState)"
     }
 }
 

--- a/core/src/main/java/gatt/Gatt.kt
+++ b/core/src/main/java/gatt/Gatt.kt
@@ -36,6 +36,16 @@ import kotlinx.coroutines.flow.onEach
 typealias GattConnectionStatus = Int
 
 /**
+ * Represents the possible GATT states as defined in [BluetoothProfile]:
+ *
+ * - [BluetoothProfile.STATE_DISCONNECTED]
+ * - [BluetoothProfile.STATE_CONNECTING]
+ * - [BluetoothProfile.STATE_CONNECTED]
+ * - [BluetoothProfile.STATE_DISCONNECTING]
+ */
+typealias GattConnectionState = Int
+
+/**
  * Represents the possible GATT statuses as defined in [BluetoothGatt]:
  *
  * - [BluetoothGatt.GATT_SUCCESS]
@@ -50,16 +60,6 @@ typealias GattConnectionStatus = Int
  * - [BluetoothGatt.GATT_FAILURE]
  */
 typealias GattStatus = Int
-
-/**
- * Represents the possible GATT states as defined in [BluetoothProfile]:
- *
- * - [BluetoothProfile.STATE_DISCONNECTED]
- * - [BluetoothProfile.STATE_CONNECTING]
- * - [BluetoothProfile.STATE_CONNECTED]
- * - [BluetoothProfile.STATE_DISCONNECTING]
- */
-typealias GattState = Int
 
 /**
  * Represents the possible [BluetoothGattCharacteristic] write types:
@@ -118,11 +118,11 @@ suspend fun Gatt.writeCharacteristic(
     value: ByteArray
 ): OnCharacteristicWrite = writeCharacteristic(characteristic, value, WRITE_TYPE_DEFAULT)
 
-internal suspend fun Gatt.suspendUntilConnectionState(state: GattState) {
-    Able.debug { "Suspending until ${state.asGattStateString()}" }
+internal suspend fun Gatt.suspendUntilConnectionState(state: GattConnectionState) {
+    Able.debug { "Suspending until ${state.asGattConnectionStateString()}" }
     onConnectionStateChange
         .onEach { event ->
-            Able.verbose { "← Received $event while waiting for ${state.asGattStateString()}" }
+            Able.verbose { "← Received $event while waiting for ${state.asGattConnectionStateString()}" }
             if (event.status != GATT_SUCCESS) throw GattStatusFailure(event)
         }
         .firstOrNull { (_, newState) -> newState == state }
@@ -136,6 +136,6 @@ internal suspend fun Gatt.suspendUntilConnectionState(state: GattState) {
             }
         }
         ?.also { (_, newState) ->
-            Able.info { "Reached ${newState.asGattStateString()}" }
+            Able.info { "Reached ${newState.asGattConnectionStateString()}" }
         }
 }

--- a/core/src/main/java/gatt/GattCallback.kt
+++ b/core/src/main/java/gatt/GattCallback.kt
@@ -54,7 +54,7 @@ internal class GattCallback(
     override fun onConnectionStateChange(
         gatt: BluetoothGatt,
         status: GattConnectionStatus,
-        newState: GattState
+        newState: GattConnectionState
     ) {
         val event = OnConnectionStateChange(status, newState)
         Able.debug { "← $event" }


### PR DESCRIPTION
Renamed to be more similar to it's `GattConnectionStatus` counterpart.