### PR TITLE
Add OnServicesDiscovered event

### DIFF
--- a/core/src/main/java/gatt/CoroutinesGatt.kt
+++ b/core/src/main/java/gatt/CoroutinesGatt.kt
@@ -53,9 +53,9 @@ class CoroutinesGatt internal constructor(
     }
 
     override suspend fun discoverServices(): GattStatus =
-        performBluetoothAction("discoverServices") {
+        performBluetoothAction<OnServicesDiscovered>("discoverServices") {
             bluetoothGatt.discoverServices()
-        }
+        }.status
 
     override suspend fun readCharacteristic(
         characteristic: BluetoothGattCharacteristic

--- a/core/src/main/java/gatt/Events.kt
+++ b/core/src/main/java/gatt/Events.kt
@@ -18,6 +18,12 @@ data class OnConnectionStateChange(
     }
 }
 
+internal data class OnServicesDiscovered(
+    val status: GattStatus
+) {
+    override fun toString() = "OnServicesDiscovered(status=${status.asGattStatusString()})"
+}
+
 data class OnMtuChanged(
     val mtu: Int,
     val status: GattStatus

--- a/core/src/main/java/gatt/GattCallback.kt
+++ b/core/src/main/java/gatt/GattCallback.kt
@@ -76,8 +76,7 @@ internal class GattCallback(
     }
 
     override fun onServicesDiscovered(gatt: BluetoothGatt, status: GattStatus) {
-        Able.verbose { "← OnServicesDiscovered(status=${status.asGattStatusString()})" }
-        onResponse.offer(status)
+        emitEvent(OnServicesDiscovered(status))
     }
 
     override fun onCharacteristicRead(

--- a/core/src/test/java/EventsTest.kt
+++ b/core/src/test/java/EventsTest.kt
@@ -12,6 +12,7 @@ import com.juul.able.gatt.OnCharacteristicRead
 import com.juul.able.gatt.OnDescriptorRead
 import com.juul.able.gatt.OnMtuChanged
 import com.juul.able.gatt.OnReadRemoteRssi
+import com.juul.able.gatt.OnServicesDiscovered
 import com.juul.able.test.gatt.FakeBluetoothGattCharacteristic as FakeCharacteristic
 import com.juul.able.test.gatt.FakeBluetoothGattDescriptor as FakeDescriptor
 import java.util.UUID
@@ -22,6 +23,16 @@ import nl.jqno.equalsverifier.EqualsVerifier
 private val testUuid = "01234567-89ab-cdef-0123-456789abcdef".toUuid()
 
 class EventsTest {
+
+    @Test
+    fun `Verify toString of OnServicesDiscovered`() {
+        val event = OnServicesDiscovered(status = GATT_SUCCESS)
+
+        assertEquals(
+            expected = "OnServicesDiscovered(status=GATT_SUCCESS(0))",
+            actual = event.toString()
+        )
+    }
 
     @Test
     fun `Verify equals of OnCharacteristicRead`() {


### PR DESCRIPTION
Encapsulates the service discovery response in `OnServicesDiscovered` event class, making it consistent with how other events are propagated.

Improves the logging of the event (in `CoroutinesGatt.performBluetoothAction`). Prior to this change the response was logged as:

```
I/Able: onServicesDiscovered ← 0
```

By wrapping in event class, log will now appear as:

```
I/Able: onServicesDiscovered ← OnServicesDiscovered(status=GATT_SUCCESS(0))
```