### PR TITLE
Drop ExperimentalCoroutinesApi annotation in GattCallback

### DIFF
--- a/core/src/main/java/gatt/GattCallback.kt
+++ b/core/src/main/java/gatt/GattCallback.kt
@@ -13,7 +13,6 @@ import android.bluetooth.BluetoothProfile.STATE_DISCONNECTING
 import com.juul.able.Able
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
@@ -24,12 +23,8 @@ internal class GattCallback(
     private val dispatcher: ExecutorCoroutineDispatcher
 ) : BluetoothGattCallback() {
 
-    @ExperimentalCoroutinesApi
     val onConnectionStateChange = BroadcastChannel<OnConnectionStateChange>(CONFLATED)
-
-    @ExperimentalCoroutinesApi
     val onCharacteristicChanged = BroadcastChannel<OnCharacteristicChanged>(BUFFERED)
-
     val onResponse = Channel<Any>(CONFLATED)
 
     private val isClosed = AtomicBoolean()


### PR DESCRIPTION
Since `GattCallback` in an `internal` class, it's properties are not part of the public API, so using `@ExperimentalCoroutinesApi` is superfluous.