### PR TITLE
Split ConnectGattResult.Failure into specific failure cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sealed class ConnectGattResult {
     data class Success(val gatt: Gatt) : ConnectGattResult()
 
     sealed class Failure : ConnectGattResult() {
+
         /** Android's `BluetoothDevice.connectGatt` returned `null` (e.g. BLE unsupported). */
         data class Rejected(val cause: Exception) : Failure()
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ traditionally rely on [`BluetoothGattCallback`] calls with [suspension functions
 ```kotlin
 sealed class ConnectGattResult {
     data class Success(val gatt: Gatt) : ConnectGattResult()
-    data class Failure(val cause: Exception) : ConnectGattResult()
+
+    sealed class Failure : ConnectGattResult() {
+        /** Android's `BluetoothDevice.connectGatt` returned `null` (e.g. BLE unsupported). */
+        data class Rejected(val cause: Exception) : Failure()
+
+        /** Connection could not be established (e.g. device is out of range). */
+        data class Connection(val cause: Exception) : Failure()
+    }
 }
 ```
 

--- a/core/src/main/java/device/CoroutinesDevice.kt
+++ b/core/src/main/java/device/CoroutinesDevice.kt
@@ -27,7 +27,7 @@ internal class CoroutinesDevice(
         val dispatcher = newSingleThreadContext("$DISPATCHER_NAME@$device")
         val callback = GattCallback(dispatcher)
         val bluetoothGatt = device.connectGatt(context, false, callback)
-            ?: return Failure(
+            ?: return Failure.Rejected(
                 RemoteException("`BluetoothDevice.connectGatt` returned `null` for device $device")
             )
 
@@ -44,7 +44,7 @@ internal class CoroutinesDevice(
             Able.warn { "connectGatt() failed for $this" }
             callback.close(bluetoothGatt)
             dispatcher.close()
-            Failure(ConnectionFailed("Failed to connect to device $device", failure))
+            Failure.Connection(failure)
         }
     }
 

--- a/core/src/main/java/device/Device.kt
+++ b/core/src/main/java/device/Device.kt
@@ -4,19 +4,29 @@
 
 package com.juul.able.device
 
+import android.bluetooth.BluetoothDevice
 import android.content.Context
 import com.juul.able.gatt.Gatt
-
-class ConnectionFailed(message: String, cause: Throwable) : IllegalStateException(message, cause)
 
 sealed class ConnectGattResult {
     data class Success(
         val gatt: Gatt
     ) : ConnectGattResult()
 
-    data class Failure(
-        val cause: Exception
-    ) : ConnectGattResult()
+    sealed class Failure : ConnectGattResult() {
+
+        abstract val cause: Exception
+
+        /** Android's [BluetoothDevice.connectGatt] returned `null` (e.g. BLE unsupported). */
+        data class Rejected(
+            override val cause: Exception
+        ) : Failure()
+
+        /** Connection could not be established (e.g. device is out of range). */
+        data class Connection(
+            override val cause: Exception
+        ) : Failure()
+    }
 }
 
 interface Device {

--- a/throw/src/main/java/android/BluetoothDeviceOrThrow.kt
+++ b/throw/src/main/java/android/BluetoothDeviceOrThrow.kt
@@ -7,14 +7,18 @@ package com.juul.able.throwable.android
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt.GATT_SUCCESS
 import android.content.Context
+import android.os.RemoteException
 import com.juul.able.android.connectGatt
 import com.juul.able.device.ConnectGattResult.Failure
 import com.juul.able.device.ConnectGattResult.Success
-import com.juul.able.device.ConnectionFailed
+import com.juul.able.gatt.ConnectionLost
 import com.juul.able.gatt.Gatt
+import com.juul.able.gatt.GattStatusFailure
 
 /**
- * @throws ConnectionFailed if underlying [BluetoothDevice.connectGatt] returns `null` or an error (non-[GATT_SUCCESS] status) occurs during connection process.
+ * @throws RemoteException if underlying [BluetoothDevice.connectGatt] returns `null`.
+ * @throws GattStatusFailure if non-[GATT_SUCCESS] status occurs during connection process.
+ * @throws ConnectionLost if disconnect is requested during connection process.
  */
 suspend fun BluetoothDevice.connectGattOrThrow(
     context: Context

--- a/throw/src/test/java/android/BluetoothDeviceTest.kt
+++ b/throw/src/test/java/android/BluetoothDeviceTest.kt
@@ -19,10 +19,10 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
 
 class BluetoothDeviceTest {
 

--- a/throw/src/test/java/android/BluetoothDeviceTest.kt
+++ b/throw/src/test/java/android/BluetoothDeviceTest.kt
@@ -9,9 +9,8 @@ import android.bluetooth.BluetoothGatt.GATT_FAILURE
 import android.bluetooth.BluetoothProfile.STATE_DISCONNECTED
 import android.content.Context
 import com.juul.able.android.connectGatt
-import com.juul.able.device.ConnectGattResult
+import com.juul.able.device.ConnectGattResult.Failure
 import com.juul.able.device.ConnectGattResult.Success
-import com.juul.able.device.ConnectionFailed
 import com.juul.able.gatt.Gatt
 import com.juul.able.gatt.GattStatusFailure
 import com.juul.able.gatt.OnConnectionStateChange
@@ -20,10 +19,10 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlinx.coroutines.runBlocking
 
 class BluetoothDeviceTest {
 
@@ -54,25 +53,16 @@ class BluetoothDeviceTest {
     fun `connectGattOrThrow throws result cause on failure`() {
         val context = mockk<Context>()
         val bluetoothDevice = mockk<BluetoothDevice>()
-        val event = OnConnectionStateChange(GATT_FAILURE, STATE_DISCONNECTED)
-        val cause = GattStatusFailure(event)
-        val failure = ConnectionFailed("Failed to connect to device 00:11:22:33:FF:EE", cause)
-        mockkStatic("com.juul.able.android.BluetoothDeviceKt")
-        try {
-            coEvery { bluetoothDevice.connectGatt(any()) } returns ConnectGattResult.Failure(failure)
+        val cause = GattStatusFailure(OnConnectionStateChange(GATT_FAILURE, STATE_DISCONNECTED))
 
-            val capturedCause = assertFailsWith<ConnectionFailed> {
+        mockkStatic("com.juul.able.android.BluetoothDeviceKt") {
+            coEvery { bluetoothDevice.connectGatt(any()) } returns Failure.Connection(cause)
+
+            assertFailsWith<GattStatusFailure> {
                 runBlocking {
                     bluetoothDevice.connectGattOrThrow(context)
                 }
-            }.cause!!
-
-            assertEquals(
-                expected = cause,
-                actual = capturedCause
-            )
-        } finally {
-            unmockkStatic("com.juul.able.android.BluetoothDeviceKt")
+            }
         }
     }
 }


### PR DESCRIPTION
Allows callers simpler access to the failure state when establishing a GATT connection.

When Android's `BluetoothDevice.connectGatt` function returns `null` it's likely due to a BLE failure (e.g. BLE not available), and caller may not want to retry.

Rather than having to examine the `cause` in the `Failure`, `Failure` is now a `sealed class` and can either be a `Failure.Rejected` or `Failure.Connection`.