### PR TITLE
Expose backing BroadcastChannel for characteristic changes

### DIFF
--- a/core/src/main/java/gatt/CoroutinesGatt.kt
+++ b/core/src/main/java/gatt/CoroutinesGatt.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -36,8 +37,15 @@ class CoroutinesGatt internal constructor(
     @FlowPreview
     override val onConnectionStateChange = callback.onConnectionStateChange.asFlow()
 
+    @Deprecated(
+        message = "Will be removed when Kotlin/kotlinx.coroutines#2034 is closed; use onCharacteristicChanged instead.",
+        replaceWith = ReplaceWith(expression = "onCharacteristicChanged")
+    )
+    override val onCharacteristicChangedChannel: BroadcastChannel<OnCharacteristicChanged>
+        get() = callback.onCharacteristicChanged
+
     @FlowPreview
-    override val onCharacteristicChanged = callback.onCharacteristicChanged.asFlow()
+    override val onCharacteristicChanged = onCharacteristicChangedChannel.asFlow()
 
     override val services: List<BluetoothGattService> get() = bluetoothGatt.services
     override fun getService(uuid: UUID): BluetoothGattService? = bluetoothGatt.getService(uuid)

--- a/core/src/main/java/gatt/GattIo.kt
+++ b/core/src/main/java/gatt/GattIo.kt
@@ -12,6 +12,7 @@ import android.bluetooth.BluetoothGattService
 import android.os.RemoteException
 import java.util.UUID
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -49,6 +50,13 @@ interface GattIo {
 
     val services: List<BluetoothGattService>
     fun getService(uuid: UUID): BluetoothGattService?
+
+    /** Will be removed when https://github.com/Kotlin/kotlinx.coroutines/issues/2034 is closed. */
+    @Deprecated(
+        message = "Will be removed when Kotlin/kotlinx.coroutines#2034 is closed; use onCharacteristicChanged instead.",
+        replaceWith = ReplaceWith(expression = "onCharacteristicChanged")
+    )
+    val onCharacteristicChangedChannel: BroadcastChannel<OnCharacteristicChanged>
 
     @FlowPreview
     val onCharacteristicChanged: Flow<OnCharacteristicChanged>


### PR DESCRIPTION
`Flow`'s `onStart` is called **before** subscribing to underlying data stream. When writing to a characteristic and expecting to receive the response via a characteristic changed event, if the `Flow` is slow to subscribe then the response could be lost.

Problem is described/discussed in Kotlin/kotlinx.coroutines#1758 and will be fixed with Kotlin/kotlinx.coroutines#2034.

The workaround is to use `openSubscription().consumeAsFlow()` which opens the subscription prior to spinning up the `Flow` (and in turn will be subscribed before the `Flow`'s `onStart`).