### PR TITLE
Have onConnectionStateChange backed by StateFlow

### DIFF
--- a/core/src/main/java/gatt/CoroutinesGatt.kt
+++ b/core/src/main/java/gatt/CoroutinesGatt.kt
@@ -34,7 +34,7 @@ class CoroutinesGatt internal constructor(
 ) : Gatt {
 
     @FlowPreview
-    override val onConnectionStateChange = callback.onConnectionStateChange.asFlow()
+    override val onConnectionStateChange = callback.onConnectionStateChange
 
     @FlowPreview
     override val onCharacteristicChanged = callback.onCharacteristicChanged.asFlow()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
 ext.deps = [
     kotlin: [
         stdlib: "org.jetbrains.kotlin:kotlin-stdlib",
-        coroutines: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5",
+        coroutines: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7",
         junit: "org.jetbrains.kotlin:kotlin-test-junit",
     ],
 


### PR DESCRIPTION
Changes `onConnectionStateChange` property to be backed by [`StateFlow`](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-state-flow/index.html) instead of `ConflatedBroadcastChannel`:

> Conceptually state flow is similar to `ConflatedBroadcastChannel` and is designed to completely replace `ConflatedBroadcastChannel` in the future.