### PR TITLE
Mark logger functions internal

### DIFF
--- a/core/src/main/java/Able.kt
+++ b/core/src/main/java/Able.kt
@@ -18,31 +18,31 @@ object Able {
     @Volatile
     var logger: Logger = AndroidLogger()
 
-    inline fun assert(throwable: Throwable? = null, message: () -> String) {
+    internal inline fun assert(throwable: Throwable? = null, message: () -> String) {
         log(ASSERT, throwable, message)
     }
 
-    inline fun error(throwable: Throwable? = null, message: () -> String) {
+    internal inline fun error(throwable: Throwable? = null, message: () -> String) {
         log(ERROR, throwable, message)
     }
 
-    inline fun warn(throwable: Throwable? = null, message: () -> String) {
+    internal inline fun warn(throwable: Throwable? = null, message: () -> String) {
         log(WARN, throwable, message)
     }
 
-    inline fun info(throwable: Throwable? = null, message: () -> String) {
+    internal inline fun info(throwable: Throwable? = null, message: () -> String) {
         log(INFO, throwable, message)
     }
 
-    inline fun debug(throwable: Throwable? = null, message: () -> String) {
+    internal inline fun debug(throwable: Throwable? = null, message: () -> String) {
         log(DEBUG, throwable, message)
     }
 
-    inline fun verbose(throwable: Throwable? = null, message: () -> String) {
+    internal inline fun verbose(throwable: Throwable? = null, message: () -> String) {
         log(VERBOSE, throwable, message)
     }
 
-    inline fun log(priority: Int, throwable: Throwable? = null, message: () -> String) {
+    internal inline fun log(priority: Int, throwable: Throwable? = null, message: () -> String) {
         if (logger.isLoggable(priority)) {
             logger.log(priority, throwable, message.invoke())
         }


### PR DESCRIPTION
Overlooked these being on the public API.
Caught it when running `./gradlew apiDump` in #56.