### PR TITLE
Split suspendUntilConnectionState into specialized functions

### DIFF
--- a/core/src/main/java/gatt/GattConnection.kt
+++ b/core/src/main/java/gatt/GattConnection.kt
@@ -8,13 +8,9 @@ package com.juul.able.gatt
 
 import android.bluetooth.BluetoothGatt.GATT_SUCCESS
 import android.bluetooth.BluetoothProfile
-import android.bluetooth.BluetoothProfile.STATE_DISCONNECTED
-import com.juul.able.Able
 import java.io.IOException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onEach
 
 /**
  * Represents the possible GATT connection statuses as defined in the Android source code.
@@ -57,17 +53,3 @@ class ConnectionLost internal constructor(
     message: String? = null,
     cause: Throwable? = null
 ) : IOException(message, cause)
-
-internal suspend fun GattConnection.suspendUntilConnectionState(state: GattConnectionState) {
-    Able.debug { "Suspending until ${state.asGattConnectionStateString()}" }
-    onConnectionStateChange
-        .onEach { event ->
-            Able.verbose { "← Received $event while waiting for ${state.asGattConnectionStateString()}" }
-            if (event.status != GATT_SUCCESS) throw GattErrorStatus(event)
-            if (event.newState == STATE_DISCONNECTED && state != STATE_DISCONNECTED) throw ConnectionLost()
-        }
-        .first { (_, newState) -> newState == state }
-        .also { (_, newState) ->
-            Able.info { "Reached ${newState.asGattConnectionStateString()}" }
-        }
-}


### PR DESCRIPTION
Having a function specific for suspension while waiting for **connect** and **disconnect** allowed for more informative logging and more readable code.

For example, reaching a disconnected state is only a failure while suspending until a **connected** state (so it just complicated the function when the function was used for **disconnect**).